### PR TITLE
Removendo o handler do helpertext e colocando essa logica de mudanca de errorMode pra dentro do Tip

### DIFF
--- a/frontend/components/DetailFormDialog.jsx
+++ b/frontend/components/DetailFormDialog.jsx
@@ -43,10 +43,6 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
         }
     }, [course, setValue])
 
-    const handleHelperText = (defaultText, error) => {
-        return error ? <Tip text={error.message} errorMode /> : <Tip text={defaultText} />
-    }
-
     // Funcao que salva os campos e adiciona eles no array
     const handleSave = handleSubmit((data) => {
         const newCourse = {
@@ -83,20 +79,24 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
                             label="Nome"
                             required
                             error={!!errors.displayName}
-                            helperText={handleHelperText(
-                                "O nome completo do componente curricular",
-                                errors.displayName
-                            )}
+                            helperText={
+                                <Tip
+                                    text={"O nome completo do componente curricular"}
+                                    errorMessage={errors.displayName}
+                                />
+                            }
                             {...register("displayName", { required: "Campo obrigatório" })}
                         />
 
                         <TextField
                             label="Aliás"
                             error={!!errors.alias}
-                            helperText={handleHelperText(
-                                "Uma abreviatura/sigla para o componente curricular",
-                                errors.alias
-                            )}
+                            helperText={
+                                <Tip
+                                    text={"Uma abreviatura/sigla para o componente curricular"}
+                                    errorMessage={errors.alias}
+                                />
+                            }
                             {...register("alias", {
                                 maxLength: {
                                     value: 12,
@@ -109,10 +109,12 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
                             label="Período"
                             required
                             error={!!errors.period}
-                            helperText={handleHelperText(
-                                "O periodo que se deseja cumprir o componente curricular",
-                                errors.period
-                            )}
+                            helperText={
+                                <Tip
+                                    text={"O periodo que se deseja cumprir o componente curricular"}
+                                    errorMessage={errors.period}
+                                />
+                            }
                             type="number"
                             {...register("period", {
                                 required: "Campo obrigatório",
@@ -127,10 +129,12 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
                             required
                             error={!!errors.code}
                             disabled={isEditingMode}
-                            helperText={handleHelperText(
-                                "Um codigo unico para o componente curricular",
-                                errors.code
-                            )}
+                            helperText={
+                                <Tip
+                                    text={"Um codigo unico para o componente curricular"}
+                                    errorMessage={errors.code}
+                                />
+                            }
                             {...register("code", {
                                 required: "Campo obrigatório",
                                 pattern: {
@@ -159,10 +163,14 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
                                             label="Natureza"
                                             required
                                             error={!!errors.nature}
-                                            helperText={handleHelperText(
-                                                "A obrigatoriedade do componente curricular",
-                                                errors.nature
-                                            )}
+                                            helperText={
+                                                <Tip
+                                                    text={
+                                                        "A obrigatoriedade do componente curricular"
+                                                    }
+                                                    errorMessage={errors.nature}
+                                                />
+                                            }
                                         />
                                     )}
                                 />
@@ -173,10 +181,12 @@ export default function DetailFormDialog({ open, onClose, addData, course = unde
                             label="Carga horária"
                             required
                             error={!!errors.workloud}
-                            helperText={handleHelperText(
-                                "O carga horária do componente curricular (em horas)",
-                                errors.workloud
-                            )}
+                            helperText={
+                                <Tip
+                                    text={"O carga horária do componente curricular (em horas)"}
+                                    errorMessage={errors.workloud}
+                                />
+                            }
                             type="number"
                             {...register("workloud", {
                                 required: "Campo obrigatório",

--- a/frontend/components/Tip.jsx
+++ b/frontend/components/Tip.jsx
@@ -2,8 +2,8 @@ import { Box, Typography } from "@mui/material"
 import ReportSharpIcon from "@mui/icons-material/ReportSharp"
 import HelpSharpIcon from "@mui/icons-material/HelpSharp"
 
-export default function Tip({ text, errorMode }) {
-    const isErrorMode = errorMode === undefined ? false : true
+export default function Tip({ text, errorMessage }) {
+    const isErrorMode = errorMessage === undefined ? false : true
 
     return (
         <Box
@@ -20,7 +20,7 @@ export default function Tip({ text, errorMode }) {
         >
             {isErrorMode ? <ReportSharpIcon /> : <HelpSharpIcon />}
             <Typography variant="body3" sx={{ mx: 1, color: "#FFFFFF" }}>
-                {text}
+                {isErrorMode ? errorMessage.message : text}
             </Typography>
         </Box>
     )

--- a/frontend/components/__test__/Tip.test.js
+++ b/frontend/components/__test__/Tip.test.js
@@ -4,20 +4,18 @@ import "@testing-library/jest-dom/extend-expect"
 
 /* UNDER DEVELOPMENT */
 
-describe ('Tip', () => {
+describe("Tip", () => {
     it('should render Tip with "#DB3B4B" bg color when errorMode is true', () => {
-        render (<Tip text={'TesteTrue'} errorMode={false} />)
+        render(<Tip text={"TesteTrue"} />)
 
-    //     const boxElement = screen.getByTestId('tip-box')
-    //     expect(boxElement).toHaveStyle({background: "#DB3B4B"})        
-    // })
+        //     const boxElement = screen.getByTestId('tip-box')
+        //     expect(boxElement).toHaveStyle({background: "#DB3B4B"})
+        // })
 
-    // it('should render Tip with "#232323" bg color when errorMode is false', () => {
-    //     render (<Tip text={'TesteFalse'} errorMode={false} />)
+        // it('should render Tip with "#232323" bg color when errorMode is false', () => {
+        //     render (<Tip text={'TesteFalse'}  />)
 
-    //     const boxElement = screen.getByLabelText('TesteFalse')
-    //     expect(boxElement).toHaveStyle({background: "#232323"})        
+        //     const boxElement = screen.getByLabelText('TesteFalse')
+        //     expect(boxElement).toHaveStyle({background: "#232323"})
     })
-    
 })
-    


### PR DESCRIPTION
Novo funcionamento: Agora se o Tip recebe apenas o parâmetro texto ele fica so naquele formato apenas preto. Se ele receber o parametro errorMessage ele muda quando o erro existe e ja muda o texto pra mensagem de erro direto.
pra testar o modo de erro passe um objeto const erro={message:"Deu erro!!!"} no parametro errorMessage={erro}